### PR TITLE
fix(project): make Yjs the single source of truth for file content

### DIFF
--- a/backend/alembic/versions/c5d8a3b7e9f1_drop_files_content_with_yjs_seed.py
+++ b/backend/alembic/versions/c5d8a3b7e9f1_drop_files_content_with_yjs_seed.py
@@ -24,7 +24,7 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.sql import table, column
 
-from pycrdt import Doc
+from pycrdt import Doc, Text
 
 
 revision: str = "c5d8a3b7e9f1"
@@ -86,7 +86,7 @@ def _seed_existing_projects(conn) -> None:
 
         mutated = False
         for hash_id, content in entries:
-            text = doc.get(f"file-{hash_id}", type="text")
+            text = doc.get(f"file-{hash_id}", type=Text)
             if len(text) == 0:
                 text.insert(0, content)
                 mutated = True

--- a/backend/alembic/versions/c5d8a3b7e9f1_drop_files_content_with_yjs_seed.py
+++ b/backend/alembic/versions/c5d8a3b7e9f1_drop_files_content_with_yjs_seed.py
@@ -1,0 +1,135 @@
+"""drop files.content column, seed remaining content into Yjs state
+
+Revision ID: c5d8a3b7e9f1
+Revises: 1f4c7b9a8d2e
+Create Date: 2026-05-22 18:50:00.000000
+
+Yjs becomes the single source of truth for file content. For each project
+with files that have non-empty `files.content`, we load any existing Yjs
+state, then insert content into every file's Y.Text that is currently empty,
+and save the merged state back. Files whose Y.Text already has content keep
+the Yjs version (it reflects live edits; `files.content` is a frozen snapshot
+from creation time).
+
+This is safe to run repeatedly — the per-Y.Text emptiness check makes it
+idempotent.
+
+Downgrade re-adds the column empty. We do not decode Yjs state back into the
+column because under conflict that would be lossy.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import table, column
+
+from pycrdt import Doc
+
+
+revision: str = "c5d8a3b7e9f1"
+down_revision: Union[str, None] = "1f4c7b9a8d2e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+files_table = table(
+    "files",
+    column("id", sa.Integer),
+    column("hash_id", sa.String),
+    column("project_id", sa.Integer),
+    column("content", sa.Text),
+    column("is_folder", sa.Boolean),
+)
+
+yjs_state_table = table(
+    "yjs_document_states",
+    column("id", sa.Integer),
+    column("project_id", sa.Integer),
+    column("state", sa.LargeBinary),
+    column("created_at", sa.DateTime),
+    column("updated_at", sa.DateTime),
+)
+
+
+def _seed_existing_projects(conn) -> None:
+    project_files: dict[int, list[tuple[str, str]]] = {}
+    for row in conn.execute(
+        sa.select(
+            files_table.c.project_id,
+            files_table.c.hash_id,
+            files_table.c.content,
+        ).where(
+            files_table.c.is_folder.is_(False),
+            files_table.c.content.isnot(None),
+            files_table.c.content != "",
+        )
+    ).fetchall():
+        project_id, hash_id, content = row
+        project_files.setdefault(project_id, []).append((hash_id, content))
+
+    if not project_files:
+        return
+
+    now = sa.func.now()
+    for project_id, entries in project_files.items():
+        existing = conn.execute(
+            sa.select(
+                yjs_state_table.c.id,
+                yjs_state_table.c.state,
+            ).where(yjs_state_table.c.project_id == project_id)
+        ).first()
+
+        doc = Doc()
+        if existing is not None and existing.state:
+            doc.apply_update(existing.state)
+
+        mutated = False
+        for hash_id, content in entries:
+            text = doc.get(f"file-{hash_id}", type="text")
+            if len(text) == 0:
+                text.insert(0, content)
+                mutated = True
+
+        if not mutated and existing is not None:
+            continue
+
+        update_bytes = doc.get_update()
+        if not update_bytes:
+            continue
+
+        if existing is None:
+            conn.execute(
+                yjs_state_table.insert().values(
+                    project_id=project_id,
+                    state=update_bytes,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        else:
+            conn.execute(
+                yjs_state_table.update()
+                .where(yjs_state_table.c.id == existing.id)
+                .values(state=update_bytes, updated_at=now)
+            )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    _seed_existing_projects(conn)
+
+    op.drop_constraint("folders_no_content", "files", type_="check")
+    op.drop_column("files", "content")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "files",
+        sa.Column("content", sa.Text(), nullable=False, server_default=""),
+    )
+    op.create_check_constraint(
+        "folders_no_content",
+        "files",
+        "is_folder = false OR content = ''",
+    )

--- a/backend/app/api/files.py
+++ b/backend/app/api/files.py
@@ -16,6 +16,7 @@ from app.services.storage import storage_service
 from app.services.hash_lookup import get_project_by_ref
 from app.services.permissions import check_project_access
 from app.websocket.project_ws import project_manager
+from app.websocket.yjs_server import manager as yjs_manager
 
 router = APIRouter()
 
@@ -26,7 +27,6 @@ def _serialize_file(file: File, project_hash_id: str, file_id_to_hash: dict[int,
         project_id=project_hash_id,
         name=file.name,
         path=file.path,
-        content=file.content,
         parent_id=file_id_to_hash.get(file.parent_id) if file.parent_id else None,
         is_folder=file.is_folder,
         created_at=file.created_at,
@@ -247,7 +247,6 @@ async def create_file(
         project_id=project.id,
         name=resolved_name,
         path="/",
-        content=file_in.content,
         parent_id=parent.id if parent else None,
         is_folder=file_in.is_folder,
     )
@@ -256,6 +255,16 @@ async def create_file(
     await db.flush()
 
     file.path = await file.compute_path(db)
+
+    # Seed Yjs with the initial content before committing the file row so a
+    # Yjs write failure rolls back the DB. Folders never have content.
+    if not file_in.is_folder and file_in.content:
+        await yjs_manager.write_file_content(
+            project_id=project.id,
+            project_hash_id=project.hash_id,
+            file_hash_id=file.hash_id,
+            content=file_in.content,
+        )
 
     await db.commit()
     await db.refresh(file)
@@ -471,7 +480,6 @@ async def upload_asset(
             project_id=project.id,
             name=resolved_name,
             path="/",
-            content=decoded_content,
             parent_id=parent.id if parent else None,
             is_folder=False,
         )
@@ -479,6 +487,14 @@ async def upload_asset(
         await db.flush()
 
         created_file.path = await created_file.compute_path(db)
+
+        if decoded_content:
+            await yjs_manager.write_file_content(
+                project_id=project.id,
+                project_hash_id=project.hash_id,
+                file_hash_id=created_file.hash_id,
+                content=decoded_content,
+            )
 
         await db.commit()
         await db.refresh(created_file)

--- a/backend/app/models/file.py
+++ b/backend/app/models/file.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Text, Boolean, UniqueConstraint, CheckConstraint
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Boolean, UniqueConstraint
 from sqlalchemy.orm import relationship
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.db.base import Base
@@ -14,7 +14,6 @@ class File(Base):
     project_id = Column(Integer, ForeignKey("projects.id"), nullable=False)
     name = Column(String, nullable=False)
     path = Column(String, nullable=False)
-    content = Column(Text, nullable=False, default="")
     parent_id = Column(Integer, ForeignKey("files.id", ondelete="CASCADE"), nullable=True, index=True)
     is_folder = Column(Boolean, nullable=False, default=False, index=True)
     created_at = Column(DateTime, default=datetime.utcnow)
@@ -28,7 +27,6 @@ class File(Base):
     # Table constraints
     __table_args__ = (
         UniqueConstraint("project_id", "parent_id", "name", name="unique_name_in_directory"),
-        CheckConstraint("is_folder = false OR content = ''", name="folders_no_content"),
     )
 
     async def compute_path(self, db: AsyncSession) -> str:

--- a/backend/app/schemas/file.py
+++ b/backend/app/schemas/file.py
@@ -11,7 +11,6 @@ class FileCreate(BaseModel):
     @field_validator('content')
     @classmethod
     def validate_folder_content(cls, v: str, info) -> str:
-        # Check if is_folder field is True
         if info.data.get('is_folder') and v:
             raise ValueError('Folders cannot have content')
         return v
@@ -19,9 +18,7 @@ class FileCreate(BaseModel):
 
 class FileUpdate(BaseModel):
     name: str | None = None
-    content: str | None = None
     parent_id: str | None = None
-    # Note: is_folder is NOT in FileUpdate (immutable after creation)
 
 
 class File(BaseModel):
@@ -29,7 +26,6 @@ class File(BaseModel):
     project_id: str
     name: str
     path: str
-    content: str
     parent_id: str | None = None
     is_folder: bool
     created_at: datetime

--- a/backend/app/websocket/yjs_server.py
+++ b/backend/app/websocket/yjs_server.py
@@ -513,6 +513,76 @@ class YjsConnectionManager:
         except Exception as e:
             print(f"[YJS] Failed to notify unauthorized event: {e}")
     
+    async def write_file_content(
+        self,
+        project_id: int,
+        project_hash_id: str,
+        file_hash_id: str,
+        content: str,
+    ) -> None:
+        """Insert initial content into a file's Y.Text in the project's Yjs doc.
+
+        Called by the REST API when a file is created with non-empty content.
+        If the project's room is live, mutates the in-memory ydoc — the YRoom's
+        update observer broadcasts to connected clients and persists via the
+        ystore. If the room is dormant, loads persisted state, applies the
+        insertion, and writes back to both Redis and PostgreSQL.
+
+        Holding `room_lock` for the whole operation serializes concurrent
+        writes per project. The `len(text) == 0` check makes it idempotent so
+        a retry after a partial failure does not duplicate content.
+        """
+        if not content:
+            return
+
+        if not self._initialized:
+            await self.initialize()
+
+        room_path = f"/project-{project_hash_id}"
+        room_lock = await self._get_room_lock(room_path)
+
+        async with room_lock:
+            if self._websocket_server and room_path in self._websocket_server.rooms:
+                room = self._websocket_server.rooms[room_path]
+                text = room.ydoc.get(f"file-{file_hash_id}", type="text")
+                if len(text) == 0:
+                    text.insert(0, content)
+                return
+
+            async with self._async_session_factory() as session:
+                result = await session.execute(
+                    select(YjsDocumentState).where(YjsDocumentState.project_id == project_id)
+                )
+                yjs_state = result.scalar_one_or_none()
+
+                doc = Doc()
+                if yjs_state and yjs_state.state:
+                    doc.apply_update(yjs_state.state)
+
+                text = doc.get(f"file-{file_hash_id}", type="text")
+                if len(text) > 0:
+                    return
+                text.insert(0, content)
+
+                update_bytes = doc.get_update()
+                if not update_bytes:
+                    return
+
+                # Redis first to match encode_state_as_update: if the PostgreSQL
+                # commit fails, Redis still holds the new state and readers stay
+                # consistent until the next snapshot loop reconciles.
+                try:
+                    await self._redis_client.set(f"yjs:doc:{room_path}", update_bytes)
+                except Exception as e:
+                    print(f"[YJS] Error writing seeded state to Redis: {e}")
+
+                if yjs_state:
+                    yjs_state.state = update_bytes
+                else:
+                    yjs_state = YjsDocumentState(project_id=project_id, state=update_bytes)
+                    session.add(yjs_state)
+                await session.commit()
+
     async def serve(
         self,
         websocket: WebSocket,

--- a/backend/app/websocket/yjs_server.py
+++ b/backend/app/websocket/yjs_server.py
@@ -32,7 +32,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy import select
 import redis.asyncio as redis
 
-from pycrdt import Doc, YMessageType, YSyncMessageType
+from pycrdt import Doc, Text, YMessageType, YSyncMessageType
 from pycrdt_websocket import WebsocketServer, YRoom
 from pycrdt_websocket.ystore import BaseYStore
 from pycrdt_websocket.websocket_server import exception_logger
@@ -544,7 +544,7 @@ class YjsConnectionManager:
         async with room_lock:
             if self._websocket_server and room_path in self._websocket_server.rooms:
                 room = self._websocket_server.rooms[room_path]
-                text = room.ydoc.get(f"file-{file_hash_id}", type="text")
+                text = room.ydoc.get(f"file-{file_hash_id}", type=Text)
                 if len(text) == 0:
                     text.insert(0, content)
                 return
@@ -559,7 +559,7 @@ class YjsConnectionManager:
                 if yjs_state and yjs_state.state:
                     doc.apply_update(yjs_state.state)
 
-                text = doc.get(f"file-{file_hash_id}", type="text")
+                text = doc.get(f"file-{file_hash_id}", type=Text)
                 if len(text) > 0:
                     return
                 text.insert(0, content)

--- a/frontend/src/lib/components/editor/FileTree.svelte
+++ b/frontend/src/lib/components/editor/FileTree.svelte
@@ -17,7 +17,6 @@
   interface Props {
     files: ProjectFile[];
     assets: Asset[];
-    loadingFileIds?: Set<string>;
     selectedItem: ProjectFile | Asset | null;
     previewFileId?: string | null;
     onSelectFile: (file: ProjectFile) => void;
@@ -46,7 +45,6 @@
   let {
     files,
     assets,
-    loadingFileIds = new Set<string>(),
     selectedItem,
     previewFileId = null,
     onSelectFile,
@@ -1011,7 +1009,6 @@
               <FileTreeItem
                 item={itemWithSelection.item}
                 isSelected={itemWithSelection.isSelected}
-                isLoadingContent={!item.isAsset && !item.is_folder && loadingFileIds.has(item.id)}
                 usersViewing={itemWithSelection.usersViewing}
                 isPreview={!item.isAsset && previewFileId === item.id}
                 onSelect={() => handleSelect(item)}

--- a/frontend/src/lib/components/editor/FileTreeItem.svelte
+++ b/frontend/src/lib/components/editor/FileTreeItem.svelte
@@ -14,11 +14,9 @@
   import FolderOpen from "@lucide/svelte/icons/folder-open";
   import ChevronRight from "@lucide/svelte/icons/chevron-right";
   import ChevronDown from "@lucide/svelte/icons/chevron-down";
-  import Loader from "@lucide/svelte/icons/loader";
 
   export let item: (ProjectFile & FileTreeNode) | Asset;
   export let isSelected: boolean = false;
-  export let isLoadingContent: boolean = false;
   export let isPreview: boolean = false;
   export let onSelect: () => void;
   export let onSetPreview: (() => void) | undefined = undefined;
@@ -248,11 +246,6 @@
       {:else}
         <span class="name">{getFileName(item)}</span>
       {/if}
-      {#if isLoadingContent && !isEditing}
-        <span class="loading-badge">
-          <Loader size={12} />
-        </span>
-      {/if}
       {#if usersViewing.length > 0}
         <div class="user-indicators">
           {#each usersViewing as user}
@@ -408,10 +401,6 @@
     min-width: 0;
     padding: 2px 6px;
     margin: 0;
-  }
-
-  .loading-badge {
-    color: var(--text-primary);
   }
 
   .name-input {

--- a/frontend/src/lib/components/editor/PreviewPane.svelte
+++ b/frontend/src/lib/components/editor/PreviewPane.svelte
@@ -11,7 +11,7 @@
   import Download from "@lucide/svelte/icons/download";
   import ChevronDown from "@lucide/svelte/icons/chevron-down";
   import { browser } from '$app/environment';
-  import type { File as ProjectFile, Asset, Diagnostic } from '$lib/types';
+  import type { FileWithContent as ProjectFile, Asset, Diagnostic } from '$lib/types';
   import { assetsApi } from "../../services/api";
   import { getCachedAsset, cacheAsset } from '$lib/utils/assetCache';
   import { theme as themeStore } from '$lib/stores/theme';

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -60,11 +60,17 @@ export interface File {
   project_id: string;
   name: string;
   path: string;
-  content: string;
   parent_id: string | null;
   is_folder: boolean;
   created_at: string;
   updated_at: string;
+}
+
+// A File enriched with its live content snapshot (read from the Yjs Y.Text).
+// Used by code paths that need to read file contents (preview, search, export).
+// The base File type never carries content because Yjs is the source of truth.
+export interface FileWithContent extends File {
+  content: string;
 }
 
 export interface FileTreeNode extends File {

--- a/frontend/src/routes/(app)/editor/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/editor/[projectId]/+page.svelte
@@ -81,8 +81,6 @@
   let project = $state<Project | null>(null);
   let files = $state<ProjectFile[]>([]);
   let assets = $state<Asset[]>([]);
-  let loadingFileIds = $state<Set<string>>(new Set());
-  let isHydratingFiles = $state(false);
   let selectedFile = $state<ProjectFile | null>(null);
   let selectedAsset = $state<Asset | null>(null);
   let previewFileId = $state<string | null>(null);
@@ -446,8 +444,8 @@
   let projectSync: any = null;
   let commentSync: any = null;
   let isConnected = $state(false);
-  let isSynced = false;
-  let isLocalSynced = false;
+  let isSynced = $state(false);
+  let isLocalSynced = $state(false);
   let hasConnectedBefore = false;
 
   // Watch connection status changes
@@ -510,22 +508,7 @@
   async function loadFiles() {
     try {
       const data = await filesApi.list(projectId);
-
-      const nonFolderIds = data
-        .filter((file) => !file.is_folder)
-        .map((file) => file.id);
-
-      // Render tree quickly with metadata-first files, then hydrate content progressively.
-      files = data.map((file) =>
-        file.is_folder ? file : { ...file, content: "" },
-      );
-      loadingFileIds = new Set(nonFolderIds);
-      isHydratingFiles = nonFolderIds.length > 0;
-
-      // Let the UI render tree metadata before content hydration begins.
-      if (nonFolderIds.length > 0) {
-        await tick();
-      }
+      files = data;
 
       // If project has no files, create main.typ automatically
       if (data.length === 0 && canWrite) {
@@ -538,9 +521,6 @@
           );
           files = [mainFile];
           selectedFile = mainFile;
-          loadingFileIds = new Set();
-          isHydratingFiles = false;
-          // Set it as the preview file
           handleSetPreviewFile(mainFile.id);
           return;
         } catch (error) {
@@ -549,43 +529,14 @@
       }
 
       if (data.length > 0 && !selectedFile) {
-        // Select preview file if set, otherwise select first file
         if (previewFileId) {
           selectedFile = data.find((f) => f.id === previewFileId) || data[0];
         } else {
           selectedFile = data[0];
         }
       }
-
-      if (nonFolderIds.length === 0) {
-        isHydratingFiles = false;
-        return;
-      }
-
-      // Hydrate file content progressively after the tree is visible.
-      let hydratedCount = 0;
-      for (const hydrated of data) {
-        if (hydrated.is_folder) continue;
-
-        files = files.map((file) =>
-          file.id === hydrated.id ? { ...file, content: hydrated.content } : file,
-        );
-
-        loadingFileIds = new Set(
-          [...loadingFileIds].filter((fileId) => fileId !== hydrated.id),
-        );
-
-        hydratedCount += 1;
-        if (hydratedCount % 20 === 0) {
-          await tick();
-        }
-      }
-
-      isHydratingFiles = false;
     } catch (error) {
       console.error("Failed to load files:", error);
-      loadingFileIds = new Set();
-      isHydratingFiles = false;
     }
   }
 
@@ -1272,12 +1223,6 @@
     if (!files.find((f) => f.id === file.id)) {
       files = [...files, file];
     }
-    if (yjsConnection?.ydoc) {
-      const ytext = getFileText(yjsConnection.ydoc, file.id);
-      if (ytext && ytext.length === 0 && file.content) {
-        ytext.insert(0, file.content);
-      }
-    }
   }
 
   function onFileUpdated(file: ProjectFile) {
@@ -1440,13 +1385,6 @@
         selectedFile = null;
         await tick();
         selectedFile = reopenedFile;
-
-        if (reopenedFile && yjsConnection?.ydoc) {
-          const reopenedYtext = getFileText(yjsConnection.ydoc, reopenedFile.id);
-          if (reopenedYtext && reopenedYtext.length === 0 && reopenedFile.content) {
-            reopenedYtext.insert(0, reopenedFile.content);
-          }
-        }
       }
 
       if (selectedFile && !selectedFile.is_folder) {
@@ -1707,27 +1645,20 @@
   let fileObservers = new Map<string, () => void>();
   let contentVersion = $state(0); // Increment to trigger reactivity
 
-  // Initialize file content and set up observers
+  // Observe file content changes to trigger preview updates. Content itself
+  // is seeded server-side; the client never inserts into ytext on load.
   $effect(() => {
     if (browser && yjsConnection?.ydoc && files.length > 0) {
       const ydoc = yjsConnection.ydoc;
 
-      // Clear old observers
       fileObservers.forEach((unobserve) => unobserve());
       fileObservers.clear();
 
-      // Initialize file content and observe changes
       files.forEach((file) => {
         const ytext = getFileText(ydoc, file.id);
         if (ytext) {
-          // Initialize if empty
-          if (ytext.length === 0 && file.content) {
-            ytext.insert(0, file.content);
-          }
-
-          // Observe changes to trigger preview updates
           const handler = () => {
-            contentVersion++; // Trigger reactivity
+            contentVersion++;
           };
           ytext.observe(handler);
           fileObservers.set(file.id, () => ytext.unobserve(handler));
@@ -1804,7 +1735,7 @@
 
       return {
         ...file,
-        content: ytextForFile ? ytextForFile.toString() : file.content,
+        content: ytextForFile ? ytextForFile.toString() : "",
       };
     });
   });
@@ -2137,7 +2068,6 @@
           <FileTree
             {files}
             {assets}
-            {loadingFileIds}
             {selectedItem}
             {previewFileId}
             onSelectFile={handleSelectFile}
@@ -2346,7 +2276,7 @@
         <PreviewPane
           files={filesWithContent}
           {assets}
-          compileEnabled={!isHydratingFiles}
+          compileEnabled={isSynced || isLocalSynced}
           mainFilePath={previewFilePath}
           onDiagnostics={handleDiagnostics}
           projectName={project.name}


### PR DESCRIPTION
## Summary

Fixes file content duplicating (or quadrupling) on collaborative loads.

**Root cause.** Three places on the client (`+page.svelte:1278`, `:1447`, `:1725`) seeded the Yjs `ytext` from `file.content` the moment the editor opened, but IndexedDB and the WebSocket sync arrive asynchronously *after* that. The CRDT merges the client's seed insertion alongside the real persisted state - once per concurrent client, hence "doubles or quadruples randomly." Deterministic on every page reload of any non-empty file.

**Fix.** Yjs is now the single source of truth for file content. `files.content` is gone; the backend writes initial content directly into the Yjs document under `room_lock`, with a `len(text) == 0` idempotency check so retries can't double-insert. Clients never seed.

## Changes

**Backend**
- `models/file.py`, `schemas/file.py` — drop the `content` column, the `folders_no_content` check constraint, and the dead `content` field from `FileUpdate`.
- `websocket/yjs_server.py` — new `YjsConnectionManager.write_file_content(...)`. Mutates the live room's ydoc if one exists; otherwise loads persisted state, applies the insert, and writes Redis-first then Postgres (matches `encode_state_as_update` ordering).
- `api/files.py` — `create_file` and `upload_asset` (text branch) call `write_file_content` between `db.flush()` and `db.commit()`, so a Yjs failure rolls back the file row.
- `alembic/versions/c5d8a3b7e9f1_drop_files_content_with_yjs_seed.py` — for each project with non-empty `files.content`, loads any existing Yjs state and inserts content into every Y.Text that's still empty (live edits win over the frozen snapshot), then drops the column. Idempotent per Y.Text.

**Frontend**
- Removes all three `ytext.insert(0, file.content)` sites.
- `loadFiles` no longer progressively hydrates content — the list endpoint returns metadata only.
- `isSynced` / `isLocalSynced` promoted to `$state` so `compileEnabled={isSynced || isLocalSynced}` is actually reactive; preview waits for IDB or WS sync before first compile.
- Drops the now-unused `loadingFileIds`, `isHydratingFiles`, `isLoadingContent` state and the spinner JSX/CSS.
- Adds a `FileWithContent` type for the one consumer (`PreviewPane`) that needs the Y.Text snapshot alongside file metadata.
