### PR TITLE
Feat(project/frontend): Preview Thumbnail in the Dashboard

### DIFF
--- a/backend/alembic/versions/f6a7b8c9d0e1_add_project_thumbnail.py
+++ b/backend/alembic/versions/f6a7b8c9d0e1_add_project_thumbnail.py
@@ -1,0 +1,27 @@
+"""add project thumbnail
+
+Revision ID: f6a7b8c9d0e1
+Revises: c5d8a3b7e9f1
+Create Date: 2026-05-26 20:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f6a7b8c9d0e1"
+down_revision: Union[str, None] = "c5d8a3b7e9f1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("projects", sa.Column("thumbnail_storage_path", sa.String(), nullable=True))
+    op.add_column("projects", sa.Column("thumbnail_updated_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("projects", "thumbnail_updated_at")
+    op.drop_column("projects", "thumbnail_storage_path")

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1,7 +1,8 @@
+import io
 from datetime import datetime
 from typing import Annotated, List, Literal
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -18,7 +19,7 @@ from app.models.user import AuthUser, GuestUser, User
 from app.schemas.collaborator import Collaborator, CollaboratorAdd, CollaboratorUpdate
 from app.schemas.invitation import Invitation as InvitationSchema
 from app.schemas.project import Project as ProjectSchema
-from app.schemas.project import ProjectCreate, ProjectUpdate, ProjectWithRole
+from app.schemas.project import ProjectCreate, ProjectThumbnail, ProjectUpdate, ProjectWithRole
 from app.schemas.sharing import ShareLink, ShareLinkAccess, ShareLinksSummary, SharingOverview
 from app.services.hash_lookup import get_project_by_ref, get_user_by_hash
 from app.services.permissions import (
@@ -27,10 +28,14 @@ from app.services.permissions import (
     check_project_access,
     get_user_project_role,
 )
+from app.services.storage import storage_service
 from app.websocket.project_ws import project_manager
 from app.websocket.notifications_ws import notifications_manager
 
 router = APIRouter()
+
+MAX_THUMBNAIL_SIZE_BYTES = 1024 * 1024
+THUMBNAIL_CONTENT_TYPE = "image/png"
 
 
 def _serialize_collaborator(collaborator: ProjectCollaborator) -> Collaborator:
@@ -55,6 +60,7 @@ def _serialize_project(project: Project, current_user_role: str, owner: AuthUser
         name=project.name,
         description=project.description,
         owner_id=owner.hash_id,
+        thumbnail_updated_at=project.thumbnail_updated_at,
         created_at=project.created_at,
         updated_at=project.updated_at,
         current_user_role=current_user_role,
@@ -156,6 +162,7 @@ async def create_project(
         name=project.name,
         description=project.description,
         owner_id=current_user.hash_id,
+        thumbnail_updated_at=project.thumbnail_updated_at,
         created_at=project.created_at,
         updated_at=project.updated_at,
     )
@@ -300,6 +307,83 @@ async def get_project(
     return _serialize_project(project, role, owner, collaborators_count)
 
 
+@router.get("/{project_ref}/thumbnail", response_model=ProjectThumbnail)
+async def get_project_thumbnail(
+    project_ref: str,
+    current_user: CurrentUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+):
+    project = await get_project_by_ref(db, project_ref)
+    project = await check_project_access(db, project, current_user)
+
+    if not project.thumbnail_storage_path or not project.thumbnail_updated_at:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Project thumbnail not found",
+        )
+
+    try:
+        url = storage_service.get_presigned_url(project.thumbnail_storage_path, expires=3600)
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Project thumbnail not found",
+        )
+
+    return ProjectThumbnail(url=url, updated_at=project.thumbnail_updated_at)
+
+
+@router.put("/{project_ref}/thumbnail", response_model=ProjectThumbnail)
+async def upload_project_thumbnail(
+    project_ref: str,
+    file: UploadFile,
+    current_user: CurrentUser,
+    db: Annotated[AsyncSession, Depends(get_db)],
+):
+    project = await get_project_by_ref(db, project_ref)
+    project = await check_project_access(db, project, current_user, CollaboratorRole.WRITER)
+
+    if file.content_type != THUMBNAIL_CONTENT_TYPE:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Project thumbnail must be a PNG image",
+        )
+
+    file_content = await file.read()
+    file_size = len(file_content)
+
+    if file_size == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Uploaded file is empty",
+        )
+
+    if file_size > MAX_THUMBNAIL_SIZE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Project thumbnail must be smaller than 1MB",
+        )
+
+    object_name = f"projects/{project.hash_id}/thumbnail.png"
+    old_updated_at = project.updated_at
+
+    storage_service.upload_file(
+        object_name,
+        file_data=io.BytesIO(file_content),
+        length=file_size,
+        content_type=THUMBNAIL_CONTENT_TYPE,
+    )
+
+    project.thumbnail_storage_path = object_name
+    project.thumbnail_updated_at = datetime.utcnow()
+    project.updated_at = old_updated_at
+    await db.commit()
+    await db.refresh(project)
+
+    url = storage_service.get_presigned_url(object_name, expires=3600)
+    return ProjectThumbnail(url=url, updated_at=project.thumbnail_updated_at)
+
+
 @router.put("/{project_ref}", response_model=ProjectSchema)
 async def update_project(
     project_ref: str,
@@ -340,6 +424,9 @@ async def update_project(
                 "name": project.name,
                 "description": project.description,
                 "owner_id": owner.hash_id if owner else "",
+                "thumbnail_updated_at": project.thumbnail_updated_at.isoformat()
+                if project.thumbnail_updated_at
+                else None,
                 "created_at": project.created_at.isoformat(),
                 "updated_at": project.updated_at.isoformat(),
             },
@@ -351,6 +438,7 @@ async def update_project(
         name=project.name,
         description=project.description,
         owner_id=(await db.get(AuthUser, project.owner_id)).hash_id,
+        thumbnail_updated_at=project.thumbnail_updated_at,
         created_at=project.created_at,
         updated_at=project.updated_at,
     )
@@ -371,14 +459,18 @@ async def delete_project(
         )
 
     from app.models.asset import Asset
-    from app.services.storage import storage_service
-
     assets_result = await db.execute(select(Asset).where(Asset.project_id == project.id))
     assets = assets_result.scalars().all()
 
     for asset in assets:
         try:
             storage_service.delete_file(asset.storage_path)
+        except Exception:
+            pass
+
+    if project.thumbnail_storage_path:
+        try:
+            storage_service.delete_file(project.thumbnail_storage_path)
         except Exception:
             pass
 

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -13,6 +13,8 @@ class Project(Base):
     name = Column(String, nullable=False)
     description = Column(Text, nullable=True)
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    thumbnail_storage_path = Column(String, nullable=True)
+    thumbnail_updated_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -20,6 +20,7 @@ class ProjectUpdate(BaseModel):
 class Project(ProjectBase):
     id: str
     owner_id: str
+    thumbnail_updated_at: datetime | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -40,3 +41,8 @@ class ProjectWithRole(Project):
     current_user_role: Literal['owner', 'admin', 'writer', 'commentor', 'reader']
     owner: Optional[OwnerInfo] = None
     collaborators_count: int = 0
+
+
+class ProjectThumbnail(BaseModel):
+    url: str
+    updated_at: datetime

--- a/frontend/src/lib/components/editor/PreviewPane.svelte
+++ b/frontend/src/lib/components/editor/PreviewPane.svelte
@@ -12,7 +12,7 @@
   import ChevronDown from "@lucide/svelte/icons/chevron-down";
   import { browser } from '$app/environment';
   import type { FileWithContent as ProjectFile, Asset, Diagnostic } from '$lib/types';
-  import { assetsApi } from "../../services/api";
+  import { assetsApi, projectsApi } from "../../services/api";
   import { getCachedAsset, cacheAsset } from '$lib/utils/assetCache';
   import { theme as themeStore } from '$lib/stores/theme';
   import { saveLayoutState, loadLayoutState } from '$lib/utils/layoutStorage';
@@ -24,6 +24,8 @@
     compileEnabled?: boolean;
     mainFilePath?: string;
     onDiagnostics?: (diagnostics: Diagnostic[]) => void;
+    projectId?: string;
+    thumbnailUploadEnabled?: boolean;
     projectName?: string;
     negativePreview?: boolean;
     showToolbar?: boolean;
@@ -43,6 +45,8 @@
     compileEnabled = true,
     mainFilePath = '/main.typ',
     onDiagnostics,
+    projectId,
+    thumbnailUploadEnabled = true,
     projectName,
     negativePreview = false,
     showToolbar = true,
@@ -228,6 +232,16 @@
   let initialized = false;
   let workerReady = false;
   let latestMainFilePath: string | null = null;
+  const THUMBNAIL_WIDTH = 320;
+  const THUMBNAIL_UPLOAD_DEBOUNCE_MS = 3000;
+  const THUMBNAIL_MIN_UPLOAD_INTERVAL_MS = 120000;
+  const THUMBNAIL_CAPTURE_RETRIES = 20;
+  const THUMBNAIL_CAPTURE_RETRY_MS = 100;
+  let thumbnailUploadTimeout: ReturnType<typeof setTimeout> | null = null;
+  let thumbnailThrottleTimeout: ReturnType<typeof setTimeout> | null = null;
+  let thumbnailUploadInFlight = false;
+  let lastThumbnailUploadAt = 0;
+  let lastUploadedThumbnailSignature: string | null = null;
   
 
   // Track loaded files/assets to detect changes
@@ -427,6 +441,168 @@
     });
   }
 
+  function scheduleThumbnailUpload() {
+    if (!projectId || !thumbnailUploadEnabled || !previewIframe) return;
+    if (thumbnailUploadTimeout) clearTimeout(thumbnailUploadTimeout);
+
+    thumbnailUploadTimeout = setTimeout(() => {
+      thumbnailUploadTimeout = null;
+      requestThumbnailUpload();
+    }, THUMBNAIL_UPLOAD_DEBOUNCE_MS);
+  }
+
+  function requestThumbnailUpload() {
+    if (!projectId || !thumbnailUploadEnabled || !previewIframe) return;
+
+    const elapsed = Date.now() - lastThumbnailUploadAt;
+    const wait = lastThumbnailUploadAt
+      ? Math.max(0, THUMBNAIL_MIN_UPLOAD_INTERVAL_MS - elapsed)
+      : 0;
+
+    if (wait === 0) {
+      if (thumbnailThrottleTimeout) {
+        clearTimeout(thumbnailThrottleTimeout);
+        thumbnailThrottleTimeout = null;
+      }
+      void uploadCurrentThumbnail();
+      return;
+    }
+
+    if (thumbnailThrottleTimeout) clearTimeout(thumbnailThrottleTimeout);
+    thumbnailThrottleTimeout = setTimeout(() => {
+      thumbnailThrottleTimeout = null;
+      void uploadCurrentThumbnail();
+    }, wait);
+  }
+
+  async function uploadCurrentThumbnail() {
+    if (!projectId || !thumbnailUploadEnabled || thumbnailUploadInFlight) return;
+
+    thumbnailUploadInFlight = true;
+    try {
+      const thumbnail = await captureCurrentThumbnail();
+      if (!thumbnail || thumbnail.signature === lastUploadedThumbnailSignature) {
+        return;
+      }
+
+      await projectsApi.uploadThumbnail(projectId, thumbnail.blob);
+      lastThumbnailUploadAt = Date.now();
+      lastUploadedThumbnailSignature = thumbnail.signature;
+    } catch (error) {
+      console.warn('Failed to update project thumbnail:', error);
+    } finally {
+      thumbnailUploadInFlight = false;
+    }
+  }
+
+  async function captureCurrentThumbnail(): Promise<{ blob: Blob; signature: string } | null> {
+    const page = await waitForPreviewPage();
+    if (!page) return null;
+
+    const { svg, pageRect } = page;
+    const pageWidth = Number(pageRect.getAttribute('data-page-width'));
+    const pageHeight = Number(pageRect.getAttribute('data-page-height'));
+    if (!Number.isFinite(pageWidth) || !Number.isFinite(pageHeight) || pageWidth <= 0 || pageHeight <= 0) {
+      return null;
+    }
+
+    const { x, y } = parsePageTranslate(pageRect.getAttribute('transform') || '');
+    const height = Math.round(THUMBNAIL_WIDTH * (pageHeight / pageWidth));
+    const pageNumber = pageRect.getAttribute('data-page-number') || '0';
+    const clone = svg.cloneNode(true) as SVGSVGElement;
+    clone.querySelectorAll('.typst-svg-cursor').forEach((cursor) => cursor.remove());
+    clone.querySelectorAll('.typst-page').forEach((page) => {
+      if (page.getAttribute('data-page-number') !== pageNumber) page.remove();
+    });
+    clone.querySelectorAll('rect.typst-page-inner').forEach((rect) => {
+      if (rect.getAttribute('data-page-number') !== pageNumber) rect.remove();
+    });
+    clone.querySelectorAll('clipPath[id^="typst-page-clip-"]').forEach((clipPath) => {
+      if (clipPath.id !== `typst-page-clip-${pageNumber}`) clipPath.remove();
+    });
+    clone.querySelectorAll('.typst-preview-svg-page-number').forEach((pageNumberLabel) => pageNumberLabel.remove());
+    clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    clone.setAttribute('viewBox', `${x} ${y} ${pageWidth} ${pageHeight}`);
+    clone.setAttribute('width', `${THUMBNAIL_WIDTH}`);
+    clone.setAttribute('height', `${height}`);
+    clone.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+
+    const serializedSvg = new XMLSerializer().serializeToString(clone);
+    const blob = await renderSvgToPng(serializedSvg, THUMBNAIL_WIDTH, height);
+    if (!blob) return null;
+
+    return {
+      blob,
+      signature: await getBlobSignature(blob),
+    };
+  }
+
+  async function waitForPreviewPage(): Promise<{ svg: SVGSVGElement; pageRect: SVGRectElement } | null> {
+    for (let attempt = 0; attempt < THUMBNAIL_CAPTURE_RETRIES; attempt++) {
+      const doc = previewIframe?.contentDocument;
+      const svg = doc?.querySelector('#typst-app svg') as SVGSVGElement | null;
+      const pageRect = doc?.querySelector('rect.typst-page-inner') as SVGRectElement | null;
+
+      if (svg && pageRect) {
+        return { svg, pageRect };
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, THUMBNAIL_CAPTURE_RETRY_MS));
+    }
+
+    return null;
+  }
+
+  function parsePageTranslate(transform: string): { x: number; y: number } {
+    const match = transform.match(/translate\(([-+\d.eE]+)[,\s]+([-+\d.eE]+)\)/);
+    return {
+      x: match ? Number(match[1]) || 0 : 0,
+      y: match ? Number(match[2]) || 0 : 0,
+    };
+  }
+
+  async function renderSvgToPng(svg: string, width: number, height: number): Promise<Blob | null> {
+    const svgBlob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
+    const url = URL.createObjectURL(svgBlob);
+
+    try {
+      const image = new Image();
+      await new Promise<void>((resolve, reject) => {
+        image.onload = () => resolve();
+        image.onerror = () => reject(new Error('Failed to load rendered SVG thumbnail'));
+        image.src = url;
+      });
+
+      const canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = height;
+
+      const context = canvas.getContext('2d');
+      if (!context) return null;
+
+      context.fillStyle = '#ffffff';
+      context.fillRect(0, 0, width, height);
+      context.drawImage(image, 0, 0, width, height);
+
+      return await new Promise<Blob | null>((resolve) => {
+        canvas.toBlob(resolve, 'image/png');
+      });
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  }
+
+  async function getBlobSignature(blob: Blob): Promise<string> {
+    const buffer = await blob.arrayBuffer();
+    if (!globalThis.crypto?.subtle) return `${blob.size}:${buffer.byteLength}`;
+
+    const hash = await globalThis.crypto.subtle.digest('SHA-256', buffer);
+    return Array.from(new Uint8Array(hash))
+      .slice(0, 16)
+      .map((byte) => byte.toString(16).padStart(2, '0'))
+      .join('');
+  }
+
   // Worker Setup
   onMount(() => {
     if (!browser) return;
@@ -486,6 +662,7 @@
             } else {
               // Send vector data to iframe
               sendVectorDataToIframe(vectorData, isFirstCompile);
+              scheduleThumbnailUpload();
             }
 
             status = `Ready (${compileTime}ms)`;
@@ -565,6 +742,12 @@
     }
     if (worker) {
       worker.terminate();
+    }
+    if (thumbnailUploadTimeout) {
+      clearTimeout(thumbnailUploadTimeout);
+    }
+    if (thumbnailThrottleTimeout) {
+      clearTimeout(thumbnailThrottleTimeout);
     }
   });
 

--- a/frontend/src/lib/components/projects/ProjectGridView.svelte
+++ b/frontend/src/lib/components/projects/ProjectGridView.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
   import type { Project } from "$lib/types";
   import GridActionButton from "./GridActionButton.svelte";
+  import ProjectThumbnail from "./ProjectThumbnail.svelte";
   import RoleBadge from "$lib/components/ui/RoleBadge.svelte";
-  import fileIcon from "../../../assets/collabst-file.svg";
   import Play from "@lucide/svelte/icons/play";
   import Trash2 from "@lucide/svelte/icons/trash-2";
   import UserPlus from "@lucide/svelte/icons/user-plus";
 
-  export let projects: Project[];
-  export let onInvite: (projectId: string) => void;
-  export let onDelete: (projectId: string) => void;
+  let { projects, onInvite, onDelete } = $props<{
+    projects: Project[];
+    onInvite: (projectId: string) => void;
+    onDelete: (projectId: string) => void;
+  }>();
 </script>
 
 <div class="projects-grid">
@@ -28,7 +30,7 @@
         ></a>
 
         <div class="file-icon-container">
-          <img src={fileIcon} alt="Project file" class="file-icon" />
+          <ProjectThumbnail {project} />
 
           <div class="action-buttons">
             <GridActionButton
@@ -109,7 +111,7 @@
     transform: translateY(-4px);
   }
 
-  .project-card:hover .file-icon {
+  .project-card:hover :global(.project-thumbnail) {
     animation: jiggleAnimation 0.4s ease;
   }
 
@@ -138,13 +140,6 @@
     margin-bottom: 0.75rem;
     z-index: 2;
     pointer-events: none;
-  }
-
-  .file-icon {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-    filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.2));
   }
 
   .action-buttons {

--- a/frontend/src/lib/components/projects/ProjectThumbnail.svelte
+++ b/frontend/src/lib/components/projects/ProjectThumbnail.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  import type { Project } from "$lib/types";
+  import { projectsApi } from "$lib/services/api";
+  import fileIcon from "../../../assets/collabst-file.svg";
+
+  let { project } = $props<{
+    project: Project;
+  }>();
+
+  let thumbnailUrl = $state<string | null>(null);
+  let loadFailed = $state(false);
+  let loadRequestId = 0;
+
+  $effect(() => {
+    const projectId = project.id;
+    const thumbnailUpdatedAt = project.thumbnail_updated_at;
+    const requestId = ++loadRequestId;
+
+    thumbnailUrl = null;
+    loadFailed = false;
+
+    if (!thumbnailUpdatedAt) return;
+
+    projectsApi
+      .getThumbnail(projectId)
+      .then((thumbnail) => {
+        if (requestId === loadRequestId) {
+          thumbnailUrl = thumbnail.url;
+        }
+      })
+      .catch(() => {
+        if (requestId === loadRequestId) {
+          loadFailed = true;
+        }
+      });
+  });
+</script>
+
+<div class="project-thumbnail" class:has-thumbnail={thumbnailUrl && !loadFailed}>
+  {#if thumbnailUrl && !loadFailed}
+    <img
+      src={thumbnailUrl}
+      alt="{project.name} preview"
+      class="thumbnail-image"
+      onerror={() => (loadFailed = true)}
+    />
+  {:else}
+    <img src={fileIcon} alt="Project file" class="fallback-icon" />
+  {/if}
+</div>
+
+<style>
+  .project-thumbnail {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.2s ease;
+  }
+
+  .thumbnail-image {
+    width: auto;
+    max-width: 104px;
+    max-height: 136px;
+    object-fit: contain;
+    border-radius: 3px;
+    background: #ffffff;
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.12),
+      0 8px 24px rgba(0, 0, 0, 0.2);
+  }
+
+  .fallback-icon {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.2));
+  }
+</style>

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -18,6 +18,7 @@ import type {
   CommentThreadUpdatePayload,
   CommentReplyDTO,
   CommentReplyCreatePayload,
+  ProjectThumbnail,
 } from '../types'
 import { getApiUrl } from '../utils/urls'
 
@@ -208,6 +209,21 @@ export const projectsApi = {
 
   delete: async (id: string): Promise<void> => {
     await api.delete(`/projects/${id}`)
+  },
+
+  getThumbnail: async (id: string): Promise<ProjectThumbnail> => {
+    const { data } = await api.get<ProjectThumbnail>(`/projects/${id}/thumbnail`)
+    return data
+  },
+
+  uploadThumbnail: async (id: string, file: Blob): Promise<ProjectThumbnail> => {
+    const formData = new FormData()
+    formData.append('file', file, 'thumbnail.png')
+
+    const { data } = await api.put<ProjectThumbnail>(`/projects/${id}/thumbnail`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+    return data
   },
 
   // Collaborators

--- a/frontend/src/lib/types/index.ts
+++ b/frontend/src/lib/types/index.ts
@@ -37,6 +37,7 @@ export interface Project {
   name: string
   description: string | null
   owner_id: string
+  thumbnail_updated_at?: string | null
   created_at: string
   updated_at: string
   collaborators?: Collaborator[]
@@ -149,6 +150,11 @@ export interface ShareLinksSummary {
   read: ShareLink | null
   comment: ShareLink | null
   edit: ShareLink | null
+}
+
+export interface ProjectThumbnail {
+  url: string
+  updated_at: string
 }
 
 export interface SharingOverview {

--- a/frontend/src/routes/(app)/editor/[projectId]/+page.svelte
+++ b/frontend/src/routes/(app)/editor/[projectId]/+page.svelte
@@ -2279,6 +2279,8 @@
           compileEnabled={isSynced || isLocalSynced}
           mainFilePath={previewFilePath}
           onDiagnostics={handleDiagnostics}
+          {projectId}
+          thumbnailUploadEnabled={canWrite}
           projectName={project.name}
           {negativePreview}
           onOpenShare={() => (showShareDialog = true)}


### PR DESCRIPTION
This PR closes #118 : Each project now has a small preview of its content when we are on the dashboard.

The thumbnail logic is as follows:

- Waits 3s (THUMBNAIL_UPLOAD_DEBOUNCE_MS) after the latest successful render.
- Uploads immediately if no thumbnail was uploaded in the last 2min.
- If inside the 2-minute window (THUMBNAIL_MIN_UPLOAD_INTERVAL_MS), schedules one trailing upload when the cooldown ends.
- Skips upload if the generated thumbnail hash matches the last uploaded thumbnail.
- Clears both timers on component teardown.