### PR TITLE
Fix(frontend): favicon now shows in prod

### DIFF
--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/src/assets/collabst-mini-logo.svg" />
+    <link rel="icon" type="image/svg+xml" href="%sveltekit.assets%/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/frontend/static/favicon.svg
+++ b/frontend/static/favicon.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 13.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
+
+<svg
+   id="Layer_1"
+   xml:space="preserve"
+   viewBox="0 0 45.11857 45.11857"
+   version="1.1"
+   y="0px"
+   x="0px"
+   width="45.118568"
+   height="45.118568"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><defs
+   id="defs1"><linearGradient
+      id="linearGradient153"><stop
+        style="stop-color:#5fd6b5;stop-opacity:1;"
+        offset="0"
+        id="stop153" /><stop
+        style="stop-color:#57afd1;stop-opacity:1;"
+        offset="0.7468853"
+        id="stop155" /><stop
+        style="stop-color:#35b6cc;stop-opacity:1;"
+        offset="1"
+        id="stop154" /></linearGradient><linearGradient
+      xlink:href="#linearGradient153"
+      id="linearGradient154"
+      x1="19.031408"
+      y1="-214.08119"
+      x2="50.935062"
+      y2="-182.17754"
+      gradientUnits="userSpaceOnUse"
+      gradientTransform="translate(-12.423951,220.68864)" /></defs>
+
+
+<metadata
+   id="metadata1"><rdf:RDF><cc:Work><dc:format>image/svg+xml</dc:format><dc:type
+          rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><cc:license
+          rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" /><dc:publisher><cc:Agent
+            rdf:about="http://openclipart.org/"><dc:title>Openclipart</dc:title></cc:Agent></dc:publisher><dc:title>Signs Hazard Warning</dc:title><dc:date>2006-09-11T08:59:16</dc:date><dc:description /><dc:source>https://openclipart.org/detail/14422/signs-hazard-warning-by-h0us3s-14422</dc:source><dc:creator><cc:Agent><dc:title>h0us3s</dc:title></cc:Agent></dc:creator><dc:subject><rdf:Bag><rdf:li>hazard</rdf:li><rdf:li>sign</rdf:li><rdf:li>warning</rdf:li></rdf:Bag></dc:subject></cc:Work><cc:License
+        rdf:about="http://creativecommons.org/publicdomain/zero/1.0/"><cc:permits
+          rdf:resource="http://creativecommons.org/ns#Reproduction" /><cc:permits
+          rdf:resource="http://creativecommons.org/ns#Distribution" /><cc:permits
+          rdf:resource="http://creativecommons.org/ns#DerivativeWorks" /></cc:License></rdf:RDF></metadata><rect
+   style="fill:url(#linearGradient154);stroke:none;stroke-width:0.504627;stroke-linecap:round;stroke-miterlimit:3;paint-order:fill markers stroke"
+   id="rect152"
+   width="45.118568"
+   height="45.118568"
+   x="0"
+   y="0"
+   ry="14.478347" /><path
+   style="font-weight:bold;font-size:49.8801px;line-height:0;font-family:'Linguistics Pro';-inkscape-font-specification:'Linguistics Pro, Bold';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;stroke-width:17.0676;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-opacity:0.918397;paint-order:fill markers stroke"
+   d="m 9.6826109,27.324834 c 3.0657901,9.07376 9.6939151,11.94926 17.3093961,9.37619 4.482873,-1.51465 8.994887,-4.72407 8.838446,-12.13307 l -2.182339,-0.22546 c -0.595439,4.29316 -2.282136,6.24711 -5.252703,7.2508 -3.51069,1.18617 -7.716294,-0.0406 -10.563098,-8.46627 -2.445338,-7.23741 -1.163064,-11.1007 1.105372,-11.86714 1.890376,-0.63871 3.374264,0.72538 5.387365,3.65579 0.79779,1.1145 1.826939,1.4889 3.231202,1.01442 1.890376,-0.63871 4.154393,-2.48683 3.351449,-4.8633 C 29.612039,7.2320544 23.49929,6.9505144 18.584337,8.6111444 14.371515,10.034554 11.424345,12.354214 9.8150649,15.605874 c -1.501996,3.03489 -1.720101,7.02004 -0.132454,11.71896 z"
+   id="path152"
+   aria-label="c" /></svg>


### PR DESCRIPTION
Previously, the favicon was located in a folder inaccessible to production builds (src), only available in development. This commit puts it in %sveltekit.assets%/, which is also available in production.